### PR TITLE
Fix AcceptButton title alignment.

### DIFF
--- a/src/mobile-ui-react/AcceptButton.scss
+++ b/src/mobile-ui-react/AcceptButton.scss
@@ -9,6 +9,8 @@
 }
 
 .mui-accept-button-label {
+  display: flex;
+  align-items: center;
   height: 28px;
   line-height: 28px;
   border-radius: 14px;


### PR DESCRIPTION
In SYNCHRO Field, line-height gets overridden. I don't understand why the same doesn't happen in the iTwin Mobile sample apps, but this fixes SYNCHRO Field without breaking the sample apps.