### PR TITLE
Fix disabled input style in modal for Android

### DIFF
--- a/src/mobile-ui-react/ModalEntryFormDialog.scss
+++ b/src/mobile-ui-react/ModalEntryFormDialog.scss
@@ -68,6 +68,10 @@
     &:focus {
       outline: none;
     }
+
+    &:disabled {
+      opacity: 0.4;
+    }
   }
 }
 


### PR DESCRIPTION
On Android modal input (ModalEntryFormField) looks the same when disabled. This happens because ios and android browsers provide different styles (ios sets opacity to 0.4, Android applies other styles, which are being overriden by mobile-ui-react styles).

Android input when enabled (no change):
![Screenshot_20250416_134134](https://github.com/user-attachments/assets/a008c684-3e5b-4564-a928-265889e5e47c)
Android input when disabled (now looks greyed out when disabled, previously looked like in the image above):
![Screenshot_20250416_134139](https://github.com/user-attachments/assets/ae7fbf6c-d16e-4ea6-bf13-9cc7e63c10ef)
iOS input when enabled (no change):
![ios_enabled](https://github.com/user-attachments/assets/b3394018-79c1-4ad3-a340-1a3650a3e6c8)
iOS input when disabled (no change):
![ios_disabled](https://github.com/user-attachments/assets/7956fda1-4c7d-4e4c-bff9-fa3b1870fb95)
