### PR TITLE
Fix incorrect top returned by `useBottomPanelTop`

### DIFF
--- a/src/mobile-ui-react/BottomPanel.tsx
+++ b/src/mobile-ui-react/BottomPanel.tsx
@@ -70,17 +70,17 @@ export class BottomPanelEvents {
 export function useBottomPanelTop() {
   const [top, setTop] = React.useState<number>();
 
-  useBeUiEvent((args: BottomPanelResizeArgs) => {
+  useBeUiEvent(React.useCallback((args: BottomPanelResizeArgs) => {
     setTop(args.top);
-  }, BottomPanelEvents.onResize);
+  }, []), BottomPanelEvents.onResize);
 
-  useBeUiEvent((args: BottomPanelOpenCloseArgs) => {
+  useBeUiEvent(React.useCallback((args: BottomPanelOpenCloseArgs) => {
     setTop(args.top);
-  }, BottomPanelEvents.onOpen);
+  }, []), BottomPanelEvents.onOpen);
 
-  useBeUiEvent((_args: BottomPanelOpenCloseArgs) => {
+  useBeUiEvent(React.useCallback((_args: BottomPanelOpenCloseArgs) => {
     setTop(undefined);
-  }, BottomPanelEvents.onClose);
+  }, []), BottomPanelEvents.onClose);
 
   return top;
 }

--- a/src/mobile-ui-react/BottomPanel.tsx
+++ b/src/mobile-ui-react/BottomPanel.tsx
@@ -124,38 +124,45 @@ export interface BottomPanelProps extends CommonProps {
 export const BottomPanel = React.forwardRef((props: BottomPanelProps, forwardedRef: MutableHtmlDivRefOrFunction) => {
   const { className, style, children, isOpen, onOpen, onClose, isSplitScreen, isStandAlone, opacity, blur, appData } = props;
   const ref = React.useRef<HTMLDivElement | null>(null);
-  const [opened, setOpened] = React.useState(false);
-  // NOTE: This MUST be here. If it is inside the useEffect call, the actual value will not be read
-  // until after the animation has already started.
-  const oldTop = ref.current?.getBoundingClientRect().top;
+  const [opened, setOpened] = React.useState<boolean>();
+  const topWhenClosed = React.useRef<number>();
+
+  React.useLayoutEffect(() => {
+    if (!ref.current)
+      return;
+
+    const { height, top } = ref.current.getBoundingClientRect();
+    if (topWhenClosed.current === undefined && isOpen) {
+      // Panel initially rendered as open
+      topWhenClosed.current = top + height;
+    } else {
+      topWhenClosed.current = isOpen ? top : top + height;
+    }
+  }, [isOpen]);
 
   React.useEffect(() => {
     if (!opened && ref.current && isOpen) {
-      const height = ref.current.clientHeight;
-      onOpen?.(height);
+      onOpen?.(ref.current.clientHeight);
       setOpened(true);
-      // If we get this far oldTop will not be undefined, but the compiler doesn't know that.
-      if (oldTop !== undefined) {
-        // The 0ms setTimeout below is used to ensure that when one tab opening causes another tab to close, the onOpen
-        // event will always be emitted after the onClose event.
-        setTimeout(() => {
-          BottomPanelEvents.onOpen.emit({ div: ref.current, height, top: oldTop - height, appData });
-        }, 0);
-      }
+
+      // The 0ms setTimeout below is used to ensure that when one tab opening causes another tab to close, the onOpen
+      // event will always be emitted after the onClose event.
+      setTimeout(() => {
+        // Panel height might have changed during the timeout.
+        const height = ref.current.clientHeight;
+        BottomPanelEvents.onOpen.emit({ div: ref.current, height, top: topWhenClosed.current - height, appData });
+      }, 0);
     }
-  }, [isOpen, appData, onOpen, ref, opened, oldTop]);
+  }, [isOpen, appData, onOpen, opened]);
 
   React.useEffect(() => {
     if (opened && ref.current && !isOpen) {
       const height = ref.current.clientHeight;
       onClose?.(height);
       setOpened(false);
-      // If we get this far oldTop will not be undefined, but the compiler doesn't know that.
-      if (oldTop !== undefined) {
-        BottomPanelEvents.onClose.emit({ div: ref.current, height, top: oldTop + height, appData });
-      }
+      BottomPanelEvents.onClose.emit({ div: ref.current, height, top: topWhenClosed.current, appData });
     }
-  }, [isOpen, appData, onClose, ref, opened, oldTop]);
+  }, [isOpen, appData, onClose, opened]);
 
   const bodyStyle: any = {
     "--bottom-panel-opacity": opacity,

--- a/src/mobile-ui-react/ResizablePanel.tsx
+++ b/src/mobile-ui-react/ResizablePanel.tsx
@@ -112,32 +112,26 @@ export function ResizablePanel(props: ResizablePanelProps) {
     if (divRef.current && onResized) {
       const rect = divRef.current.getBoundingClientRect();
       const diff = newHeight - rect.height;
-      onResized(newHeight, rect.top + diff);
+      onResized(newHeight, rect.top - diff);
     }
   }, [onResized, setHeight]);
 
   /** Sets the maxHeight when initially loaded based on minInitialHeight and maxInitialHeight. */
-  React.useEffect(() => {
-    // This setTimeout wrapper was requested by Synchro Field as on Android sometimes this effect was triggered too soon resulting in their Properties
-    // panel not being resizable. Delaying the code slightly seems to fix it. Normally we'd need to ensure the component is still mounted when the
-    // timeout code runs, but this is already guarded against by ensuring divRef.current is truthy.
-    setTimeout(() => {
-      if (!isMountedRef.current) return;
-      if (divRef.current && !initialMaxHeightSet) {
-        setInitialMaxHeightSet(true);
-        let currHeight = divRef.current.clientHeight;
-        if (maxInitialHeight && currHeight > maxInitialHeight) {
-          currHeight = maxInitialHeight;
-        } else if (minInitialHeight && currHeight < minInitialHeight) {
-          currHeight = minInitialHeight;
-          if (props.heightCanExceedContents) {
-            setHeightAndCallOnResized(currHeight);
-          }
+  React.useLayoutEffect(() => {
+    if (divRef.current && !initialMaxHeightSet) {
+      setInitialMaxHeightSet(true);
+      let currHeight = divRef.current.clientHeight;
+      if (maxInitialHeight && currHeight > maxInitialHeight) {
+        currHeight = maxInitialHeight;
+      } else if (minInitialHeight && currHeight < minInitialHeight) {
+        currHeight = minInitialHeight;
+        if (props.heightCanExceedContents) {
+          setHeightAndCallOnResized(currHeight);
         }
-        updateMaxHeight(currHeight);
       }
-    }, 0);
-  }, [divRef, minInitialHeight, maxInitialHeight, initialMaxHeightSet, updateMaxHeight, props.heightCanExceedContents, setHeightAndCallOnResized, isMountedRef]);
+      updateMaxHeight(currHeight);
+    }
+  }, [minInitialHeight, maxInitialHeight, initialMaxHeightSet, updateMaxHeight, props.heightCanExceedContents, setHeightAndCallOnResized]);
 
   const onWindowResize = React.useCallback(() => {
     setTimeout(() => {


### PR DESCRIPTION
`BottomPanel` used to get panel's top from ref during render (`oldTop`) which was used to calculate updated top when emitting open/close events. However, when using React 18 the re-renders get batched which sometimes results in undefined `oldTop` if the panel is already open on initial render. In such case, `BottomPanelEvents.onOpen` would not be emitted, leading to incorrect `useBottomPanelTop` value.

The fix made a few changes:
* Use `useLayoutEffect` to get panel position on `isOpen` change.
  * The effect runs when panel rect can be obtained but before open/close animation starts.
  * The effects calculates `topWhenClosed` which seems more robust - when the panel is open, `top` depends on panel's height which might change by the time open/close event is emitted.
* Use `useLayoutEffect` to set initial max height for resizable panels.
  *  With regular `useEffect`, the panel resize caused by setting initial max height happened at an awkward time. Most of the time the `onResized` event was emitted before `onOpen` but the resize was not reflected in DOM when emitting `onOpen`. The incorrect `top` in `onOpen` event would overwrite the correct one from the previous `onResized` event.
  * The change also removed the `setTimeout` for setting the initial max height. Apparently it was needed for Properties panel to work properly in Field on Android but didn't notice any issues without it. The workaround was fairly old and the issue was reported on Android 9 devices - maybe the underlying issue sorted itself out.
* Fix miscalculated `top` in `onResized` event emitted after setting initial max height.
* Use `useCallback` for event handlers in `useBottomPanelTop`.
  * Sometimes the initial `onOpen` event was missed when running in React 17 mode with the other fixes applied. 